### PR TITLE
GHC 8 support, except apiary-purescript.

### DIFF
--- a/apiary-authenticate/apiary-authenticate.cabal
+++ b/apiary-authenticate/apiary-authenticate.cabal
@@ -19,7 +19,7 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Web.Apiary.Authenticate
   other-modules:       Web.Apiary.Authenticate.Internal
-  build-depends:       base                 >=4.6      && <4.9
+  build-depends:       base                 >=4.6      && <5.0
                      , apiary               >=1.4      && <3.0
                      , apiary-session       >=1.4      && <1.5
                      , authenticate         >=1.3.2.10 && <1.4
@@ -30,7 +30,7 @@ library
                      , http-client          >=0.3      && <0.5
                      , http-client-tls      >=0.2      && <0.3
 
-                     , data-default-class   >=0.0      && <0.1
+                     , data-default-class   >=0.0      && <0.2
                      , bytestring           >=0.10     && <0.11
                      , cereal               >=0.4      && <0.6
                      , text                 >=1.1      && <1.3

--- a/apiary-clientsession/apiary-clientsession.cabal
+++ b/apiary-clientsession/apiary-clientsession.cabal
@@ -22,7 +22,7 @@ cabal-version:       >=1.10
 
 library
   exposed-modules:     Web.Apiary.Session.ClientSession
-  build-depends:       base               >=4.6   && <4.9
+  build-depends:       base               >=4.6   && <5.0
                      , apiary             >=1.2   && <3.0
                      , apiary-cookie      >=1.2   && <1.5
                      , apiary-session     >=1.2   && <1.5
@@ -31,9 +31,9 @@ library
                      , vault              >=0.3   && <0.4
                      , cereal             >=0.4   && <0.6
                      , bytestring         >=0.10  && <0.11
-                     , time               >=1.4   && <1.6
+                     , time               >=1.4   && <1.7
                      , unix-compat        >=0.4   && <0.5
-                     , data-default-class >=0.0   && <0.1
+                     , data-default-class >=0.0   && <0.2
 
   hs-source-dirs:      src
   ghc-options:         -O2 -Wall

--- a/apiary-cookie/apiary-cookie.cabal
+++ b/apiary-cookie/apiary-cookie.cabal
@@ -18,13 +18,13 @@ cabal-version:       >=1.10
 
 library
   exposed-modules:     Web.Apiary.Cookie
-  build-depends:       base               >=4.6  && <4.9
+  build-depends:       base               >=4.6  && <5.0
                      , apiary             >=1.4  && <3.0
                      , wai                >=3.0  && <3.3
 
                      , bytestring         >=0.10 && <0.11
                      , cookie             >=0.4  && <0.5
-                     , time               >=1.4  && <1.6
+                     , time               >=1.4  && <1.7
                      , blaze-builder      >=0.3  && <0.5
                      , blaze-html         >=0.7  && <0.9
                      , web-routing

--- a/apiary-eventsource/apiary-eventsource.cabal
+++ b/apiary-eventsource/apiary-eventsource.cabal
@@ -18,7 +18,7 @@ cabal-version:       >=1.10
 
 library
   exposed-modules:     Web.Apiary.EventSource
-  build-depends:       base              >=4.6  && <4.9
+  build-depends:       base              >=4.6  && <5.0
                      , apiary            >=1.1  && <3.0
                      , blaze-builder     >=0.3  && <0.5
                      , wai-extra         >=3.0  && <3.1

--- a/apiary-helics/apiary-helics.cabal
+++ b/apiary-helics/apiary-helics.cabal
@@ -18,17 +18,17 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Web.Apiary.Helics
   other-modules:       
-  build-depends:       base               >=4.6   && <4.9
+  build-depends:       base               >=4.6   && <5.0
                      , apiary             >=1.4   && <3.0
                      , helics             >=0.5   && <0.6
                      , helics-wai         >=0.5   && <0.6
                      , vault              >=0.3   && <0.4
-                     , transformers       >=0.3   && <0.5
+                     , transformers       >=0.3   && <0.6
                      , monad-control      >=0.3   && <1.1
-                     , wai                >=3.0   && <3.1
+                     , wai                >=3.0   && <3.3
                      , bytestring         >=0.10  && <0.11
                      , text               >=1.1   && <1.3
-                     , data-default-class >=0.0   && <0.1
+                     , data-default-class >=0.0   && <0.2
                      , types-compat
 
   hs-source-dirs:      src

--- a/apiary-logger/apiary-logger.cabal
+++ b/apiary-logger/apiary-logger.cabal
@@ -18,13 +18,13 @@ cabal-version:       >=1.10
 
 library
   exposed-modules:     Web.Apiary.Logger
-  build-depends:       base               >=4.6   && <4.9
+  build-depends:       base               >=4.6   && <5.0
                      , apiary             >=1.4   && <3.0
                      , fast-logger        >=2.1   && <2.5
                      , monad-logger       >=0.3   && <0.4
-                     , data-default-class >=0.0   && <0.1
+                     , data-default-class >=0.0   && <0.2
 
-                     , transformers       >=0.2   && <0.5
+                     , transformers       >=0.2   && <0.6
                      , transformers-base  >=0.4   && <0.5
                      , monad-control      >=0.3   && <1.1
                      , lifted-base        >=0.2   && <0.3

--- a/apiary-logger/src/Web/Apiary/Logger.hs
+++ b/apiary-logger/src/Web/Apiary/Logger.hs
@@ -83,7 +83,7 @@ initLogger LogConfig{..} = initializerBracket' $ bracket
 logging :: (Has Logger es, MonadExts es m, MonadIO m) => FL.LogStr -> m ()
 logging m = getExt (Proxy :: Proxy Logger) >>= \l -> liftIO $ pushLog l m
 
-instance (Has Logger es, MonadExts es m, MonadIO m) => MonadLogger m where
+instance (Has Logger es, Monad m, MonadExts es m, MonadIO m) => MonadLogger m where
     monadLoggerLog loc src lv msg = logging $ defaultLogStr loc src lv (FL.toLogStr msg)
 
 -- | wrapper to use as MonadLogger using Logger Extenson.

--- a/apiary-memcached/apiary-memcached.cabal
+++ b/apiary-memcached/apiary-memcached.cabal
@@ -18,13 +18,13 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Web.Apiary.Memcached
   other-modules:       
-  build-depends:       base               >=4.6   && <4.9
+  build-depends:       base               >=4.6   && <5.0
                      , apiary             >=1.4   && <3.0
                      , memcached-binary   >=0.1   && <0.3
-                     , data-default-class >=0.0   && <0.1
+                     , data-default-class >=0.0   && <0.2
                      , bytestring         >=0.10  && <0.11
                      , text               >=1.1   && <1.3
-                     , transformers       >=0.3   && <0.5
+                     , transformers       >=0.3   && <0.6
                      , monad-control      >=0.3   && <1.1
                      , types-compat
   hs-source-dirs:      src

--- a/apiary-mongoDB/apiary-mongoDB.cabal
+++ b/apiary-mongoDB/apiary-mongoDB.cabal
@@ -18,13 +18,13 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Web.Apiary.MongoDB
   other-modules:       
-  build-depends:       base               >=4.6   && <4.9
+  build-depends:       base               >=4.6   && <5.0
                      , apiary             >=1.4   && <3.0
-                     , mongoDB            >=2.0   && <2.1
+                     , mongoDB            >=2.0   && <2.2
                      , resource-pool      >=0.2   && <0.3
-                     , data-default-class >=0.0   && <0.1
-                     , transformers       >=0.2   && <0.5
-                     , time               >=1.4   && <1.6
+                     , data-default-class >=0.0   && <0.2
+                     , transformers       >=0.2   && <0.6
+                     , time               >=1.4   && <1.7
                      , lifted-base        >=0.2   && <0.3
                      , bson               >=0.3   && <0.4
                      , monad-control      >=0.3   && <1.1

--- a/apiary-persistent/apiary-persistent.cabal
+++ b/apiary-persistent/apiary-persistent.cabal
@@ -18,8 +18,8 @@ cabal-version:       >=1.10
 
 library
   exposed-modules:     Web.Apiary.Database.Persist
-  build-depends:       base               >=4.6   && <4.9
-                     , persistent         >=2.1   && <2.3
+  build-depends:       base               >=4.6   && <5.0
+                     , persistent         >=2.1   && <2.7
 
                      , apiary             >=1.4   && <3.0
                      , apiary-logger      >=1.4   && <1.5
@@ -28,7 +28,7 @@ library
                      , resource-pool      >=0.2   && <0.3
 
                      , monad-logger       >=0.3   && <0.4
-                     , transformers       >=0.2   && <0.5
+                     , transformers       >=0.2   && <0.6
                      , transformers-base  >=0.4   && <0.5
                      , monad-control      >=0.3   && <1.1
                      , web-routing

--- a/apiary-session/apiary-session.cabal
+++ b/apiary-session/apiary-session.cabal
@@ -19,7 +19,7 @@ library
   exposed-modules:     Web.Apiary.Session
                        Web.Apiary.Session.Internal
   other-modules:       
-  build-depends:       base               >=4.6   && <4.9
+  build-depends:       base               >=4.6   && <5.0
                      , apiary             >=1.4   && <3.0
                      , wai                >=3.0   && <3.3
                      , web-routing

--- a/apiary-websockets/apiary-websockets.cabal
+++ b/apiary-websockets/apiary-websockets.cabal
@@ -19,7 +19,7 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Web.Apiary.WebSockets
   other-modules:       
-  build-depends:       base               >=4.6   && <4.9
+  build-depends:       base               >=4.6   && <5.0
                      , apiary             >=1.1   && <3.0
                      , wai-websockets     >=2.1   && <3.1
                      , websockets         >=0.8   && <0.10

--- a/apiary.cabal
+++ b/apiary.cabal
@@ -88,10 +88,10 @@ library
                        Control.Monad.Apiary.Filter.Internal
                        Control.Monad.Apiary.Action.Internal
                        Control.Monad.Apiary.Filter.Internal.Capture.TH
-  build-depends:       base                 >=4.6   && <4.9
-                     , template-haskell     >=2.8   && <2.11
+  build-depends:       base                 >=4.6   && <5.0
+                     , template-haskell     >=2.8   && <2.12
 
-                     , transformers         >=0.2   && <0.5
+                     , transformers         >=0.2   && <0.6
                      , transformers-base    >=0.4   && <0.5
                      , mtl                  >=2.1   && <2.3
                      , monad-control        >=0.3   && <1.1
@@ -111,11 +111,11 @@ library
                      , vault                >=0.3   && <0.4
                      , aeson                >=0.8   && <0.12
 
-                     , data-default-class   >=0.0   && <0.1
+                     , data-default-class   >=0.0   && <0.2
                      , unordered-containers >=0.2   && <0.3
                      , hashable             >=1.1   && <1.3
-                     , time                 >=1.4   && <1.6
-                     , process              >=1.2   && <1.3
+                     , time                 >=1.4   && <1.7
+                     , process              >=1.2   && <1.5
                      , unix-compat          >=0.4   && <0.5
                      , http-date            >=0.0   && <0.1
 
@@ -135,7 +135,7 @@ test-suite tasty
   other-modules:       Application
                      , Method
   type:                exitcode-stdio-1.0
-  build-depends:       base                      >=4.6   && <4.9
+  build-depends:       base                      >=4.6   && <5.0
                      , mtl                       >=2.1   && <2.3
                      , tasty                     >=0.10  && <0.12
                      , tasty-hunit               >=0.9   && <0.10

--- a/src/Control/Monad/Apiary/Internal.hs
+++ b/src/Control/Monad/Apiary/Internal.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Control.Monad.Apiary.Internal
     ( ApiaryT
@@ -207,7 +208,7 @@ instance (Monad actM, MonadBase b m) => MonadBase b (ApiaryT exts prms actM m) w
 instance Monad actM => MonadTransControl (ApiaryT exts prms actM) where
 #if MIN_VERSION_monad_control(1,0,0)
     type StT (ApiaryT exts prms actM) a = (a, ApiaryWriter exts actM)
-    liftWith f = apiaryT $ \env -> liftM (\a -> (a, mempty)) (f $ \t -> unApiaryT t env (\a w -> return (a,w)))
+    liftWith f = apiaryT $ \env -> liftM (\a -> (a, mempty :: ApiaryWriter exts actM)) (f $ \t -> unApiaryT t env (\a w -> return (a,w)))
     restoreT = apiaryT . const
 #else
     newtype StT (ApiaryT exts prms actM) a = StTApiary { unStTApiary :: (a, ApiaryWriter exts actM) }


### PR DESCRIPTION
Fix ghc-8‘ compatibility. Bump up versions of several dependencies.

Notice that the latest version of some dependencies still need base < 4.9, including bytestring-read, types-compat, web-routing, helics, helics-wai and memcached-binary. `--allow-newer` flag should be given to cabal.

The package apiary-purescript depends on old version of purescript that isn't support by GHC 8.